### PR TITLE
Refactor domain-list.yml

### DIFF
--- a/domain-list.yml
+++ b/domain-list.yml
@@ -54,10 +54,6 @@
   evidence: https://ja.ojit.com/so/linux/137072
   original: https://stackoverflow.com/questions/3129608/
   note: The domain is used for redirection to `python5.com`
-- domain: 'python5.com'
-  evidence: https://python5.com/q/umdmwrst
-  original: https://stackoverflow.com/questions/46848923/
-  note:
 - domain: 'steakrecords.com'
   evidence: https://steakrecords.com/ja/856480-easyui-and-foundation-conflict-zurb-foundation-jquery-easyui.html
   original: https://stackoverflow.com/questions/31248509/
@@ -121,10 +117,6 @@
 - domain: 'www.it-swarm.jp.net'
   evidence: https://www.it-swarm.jp.net/ja/google-chrome/chrome%e3%81%af%e6%8b%a1%e5%bc%b5%e6%a9%9f%e8%83%bd%e3%82%92%e3%81%a9%e3%81%93%e3%81%ab%e4%bf%9d%e5%ad%98%e3%81%97%e3%81%be%e3%81%99%e3%81%8b%ef%bc%9f/1071750676/
   original: https://stackoverflow.com/questions/14543896/where-does-chrome-store-extensions
-  note:
-- domain: 'jpcloud.net'
-  evidence: https://jpcloud.net/q/zujieswz
-  original: https://stackoverflow.com/q/58033366
   note:
 - domain: 'konnichiwasekai.com'
   evidence: https://konnichiwasekai.com/61198544/Android%E3%81%A7FAB%E3%81%AE%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B%E9%9A%9B%E3%81%AE%E7%A7%BB%E8%A1%8C

--- a/domain-list.yml
+++ b/domain-list.yml
@@ -63,8 +63,12 @@
   original: https://stackoverflow.com/questions/31248509/
   note:
 - domain: 'qa.codeflow.site'
-  evidence: https://qa.codeflow.site/questions/4985281/
-  original: https://stackoverflow.com/questions/4985281/
+  evidence:
+  original:
+  note: This domain is used for redirection to codeguides.site
+- domain: 'codeguides.site'
+  evidence: https://codeguides.site/questions/ja/950037/same-ajax-called-twice-jquery
+  original: https://stackoverflow.com/questions/950037/same-ajax-called-twice-jquery
   note:
 - domain: 'overcoder.net'
   evidence: https://overcoder.net/q/4014591/%D0%BA%D0%B0%D0%BA-%D0%BF%D0%BE%D0%BA%D0%B0%D0%B7%D0%B0%D1%82%D1%8C-%D0%B4%D0%B8%D0%B0%D0%BB%D0%BE%D0%B3-%D0%BF%D1%80%D0%BE%D0%B3%D1%80%D0%B5%D1%81%D1%81%D0%B0-%D0%B2-%D0%B4%D0%B2%D1%83%D1%85-%D0%B4%D0%B5%D0%B9%D1%81%D1%82%D0%B2%D0%B8%D1%8F%D1%85-%D0%BF%D1%80%D0%B8-%D0%BF%D0%B5%D1%80%D0%B5%D0%BA%D0%BB%D1%8E%D1%87%D0%B5%D0%BD%D0%B8%D0%B8-%D1%81-%D0%BE%D0%B4%D0%BD%D0%BE%D0%B3%D0%BE


### PR DESCRIPTION
- `qa.codeflow.site` is redirection for `codeguides.site` now.
- `python5.com` and `jpcloud.net` were closed.