### PR TITLE
Add 2 sites to StackOverflow splog blacklist

### DIFF
--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -90,3 +90,5 @@
 *://*.exceptionshub.com/*
 *://newbedev.com/*
 *://pretagteam.com/*
+*://www.codegrepper.com/*
+*://issueexplorer.com/*


### PR DESCRIPTION
`codegrepper.com` and `issueexplorer.com` are two new spam blog sites that scrape off StackOverflow.

Also, the site `gitmemory.com` is an annoying github.com scraper that often pollutes my search results page. Not sure if it is relevant to this repo as it is not strictly related to StackOverflow but it is just as annoying so you may consider adding it.