### PR TITLE
add coderedirect.com

### DIFF
--- a/domain-list.yml
+++ b/domain-list.yml
@@ -429,3 +429,6 @@
 - domain: 'christfever.in'
   evidence: https://christfever.in/index.php?threads/how-does-isalnum-and-isalpha-works-in-python-returning-true-when-chinese-is-included.636732/
   original: https://stackoverflow.com/questions/65011034/how-does-isalnum-and-isalpha-works-in-python-returning-true-when-chinese-is-i
+- domain: 'coderedirect.com'
+  evidence: https://coderedirect.com/questions/175898/wpf-showing-dialog-before-main-window
+  original: https://stackoverflow.com/questions/1539958/wpf-showing-dialog-before-main-window


### PR DESCRIPTION
evidence: https://coderedirect.com/questions/175898/wpf-showing-dialog-before-main-window
original: https://stackoverflow.com/questions/1539958/wpf-showing-dialog-before-main-window

Ridiculous false claim on their homepage: [Code Redirect is the largest, most trusted online community for developers to learn, share their knowledge.](https://coderedirect.com/#:~:text=Code%20Redirect%20is%20the%20largest%2C%20most%20trusted%20online%20community%20for%20developers%20to%20learn%2C%20share%20their%20knowledge.)

They also link to [their facebook page with 13 likes](https://www.facebook.com/Code-Redirect-110829467764325/)

Tons of ads, same old story..
