### PR TITLE
Revert "Add flutterhq.com"

### DIFF
--- a/domain-list.yml
+++ b/domain-list.yml
@@ -665,6 +665,3 @@
   evidence: https://jpcodeqa.com/q/668e49df85fc62cb33205735b7864305
   original: https://stackoverflow.com/questions/906455
   note: closed?
-- domain: 'flutterhq.com'
-  evidence: https://flutterhq.com/questions-and-answers/2215/how-to-use-dropdownbutton-with-same-value
-  original: https://stackoverflow.com/questions/72213309


### PR DESCRIPTION
Reverts arosh/ublacklist-stackoverflow-translation#167

`flutterhq.com` is not machine-translated sites.
Just copy sites.
I'm sorry for wrong pull request.
